### PR TITLE
Add filter options to posts page

### DIFF
--- a/migrations/003-alter.sql
+++ b/migrations/003-alter.sql
@@ -1,0 +1,1 @@
+UPDATE articles SET categories = "[" || categories || "]";

--- a/src/app.html
+++ b/src/app.html
@@ -40,7 +40,7 @@
 		</style>
 		%sveltekit.head%
 	</head>
-	<body data-sveltekit-preload-data="hover">
+	<body data-sveltekit-preload-data="hover" data-sveltekit-replacestate>
 		<div style="display: contents">%sveltekit.body%</div>
 	</body>
 </html>

--- a/src/lib/components/stackedbarchart.svelte
+++ b/src/lib/components/stackedbarchart.svelte
@@ -4,8 +4,9 @@
 	export let width: number;
 	export let height: number;
 	export let index: d3.InternMap<string, GraphData>;
+	export let category: number | null;
 
-    const padding = 32;
+	const padding = 32;
 	$: [earliest, latest] = d3.extent([...index].map(([d]) => new Date(d))) as Iterable<Date>;
 	$: numBars = Math.floor(
 		(latest.getTime() + 1000 * 3600 * 24 - earliest.getTime()) / (1000 * 3600 * 24)
@@ -57,28 +58,34 @@
 		<g bind:this={gy} transform="translate({padding}, {0})" />
 		<g>
 			{#each index as [date, values]}
-				<g
-					class="stacked-bar"
-					role="none"
-					style="margin: 0; padding; 0; gap: 0;"
-					on:mouseenter={(d) => handleMouseOver(d, { date, values })}
-					on:mouseleave={handleMouseOut}
+				<a
+					href={`posts?${category ? `category=${category}` : ''}				
+				${date ? `&start=${date}` : ''}
+				${date ? `&end=${date}` : ''}`}
 				>
-					<rect
-						fill="lightcoral"
-						x={x(new Date(date))}
-						width={Math.max((width - padding) / numBars, 1)}
-						y={y(values.images_published)}
-						height={height - padding - y(values.images_published)}
-					/>
-					<rect
-						fill="lightgreen"
-						x={x(new Date(date))}
-						width={Math.max((width - padding) / numBars, 1)}
-						y={y(values.images_published_with_alt_text)}
-						height={Math.max(height - padding - y(values.images_published_with_alt_text), 0)}
-					/>
-				</g>
+					<g
+						class="stacked-bar"
+						role="none"
+						style="margin: 0; padding; 0; gap: 0;"
+						on:mouseenter={(d) => handleMouseOver(d, { date, values })}
+						on:mouseleave={handleMouseOut}
+					>
+						<rect
+							fill="lightcoral"
+							x={x(new Date(date))}
+							width={Math.max((width - padding) / numBars, 1)}
+							y={y(values.images_published)}
+							height={height - padding - y(values.images_published)}
+						/>
+						<rect
+							fill="lightgreen"
+							x={x(new Date(date))}
+							width={Math.max((width - padding) / numBars, 1)}
+							y={y(values.images_published_with_alt_text)}
+							height={Math.max(height - padding - y(values.images_published_with_alt_text), 0)}
+						/>
+					</g>
+				</a>
 			{/each}
 		</g>
 	</svg>
@@ -87,9 +94,9 @@
 <style>
 	figure {
 		margin: 0;
-        border: 1px solid var(--text-color-theme);
-        border-radius: 1rem;
-        background: var(--secondary-color-theme);
+		border: 1px solid var(--text-color-theme);
+		border-radius: 1rem;
+		background: var(--secondary-color-theme);
 	}
 
 	.tooltip {

--- a/src/lib/components/stackedbarchart.svelte
+++ b/src/lib/components/stackedbarchart.svelte
@@ -59,6 +59,8 @@
 		<g>
 			{#each index as [date, values]}
 				<a
+					data-sveltekit-preload-data="false"
+					data-sveltekit-preload-code="false"
 					href={`posts?${category ? `category=${category}` : ''}				
 				${date ? `&start=${date}` : ''}
 				${date ? `&end=${date}` : ''}`}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -38,8 +38,6 @@
 		}),
 		(d) => d.date
 	);
-
-	$: console.log(index);
 </script>
 
 <svelte:window bind:innerHeight bind:innerWidth />

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -47,13 +47,14 @@
 		<h2>Tracking The Daily's alternative text</h2>
 		<p>
 			The Daily has been tracking the number of images published with and without alternative text
-			since December 2022. The charts below respectively shows the number of images published with and without
-			alternative text each day, and the running average percent of images published with alternative text. 
+			since December 2022. The charts below respectively shows the number of images published with
+			and without alternative text each day, and the running average percent of images published
+			with alternative text.
 		</p>
 		<div class="options">
 			<div>
 				<label for="timerange">Select timerange:</label>
-				<select bind:value={timerange}>
+				<select id="timerange" bind:value={timerange}>
 					<option value={all}></option>
 					<option value={lastWeek}>Last week</option>
 					<option value={lastMonth}>Last month</option>
@@ -63,7 +64,7 @@
 			</div>
 			<div>
 				<label for="category">Select category:</label>
-				<select bind:value={category}>
+				<select id="category" bind:value={category}>
 					<option value={null}>All</option>
 					<option value={46}>News</option>
 					<option value={44}>Sports</option>
@@ -89,7 +90,7 @@
 				<span>Images published without alternative text</span>
 			</div>
 		</div>
-		<StackedBarChart {width} {height} {index} />
+		<StackedBarChart {width} {height} {index} {category} />
 	</section>
 	<section>
 		<div class="legend">

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -34,10 +34,12 @@
 			).length,
 			images_published: d3.sum(v.map((a) => a.images_published)),
 			images_published_with_alt_text: d3.sum(v.map((a) => a.images_published_with_alt_text)),
-			categories: d3.union(v.map((a) => a.categories.split(',')).flat())
+			categories: d3.union(v.map((a) => JSON.parse(a.categories)).flat())
 		}),
 		(d) => d.date
 	);
+
+	$: console.log(index);
 </script>
 
 <svelte:window bind:innerHeight bind:innerWidth />

--- a/src/routes/posts/+page.svelte
+++ b/src/routes/posts/+page.svelte
@@ -4,9 +4,9 @@
 
 	export let data;
 
-	$: category = data.category ?? null;
-	$: start = data.start ?? null;
-	$: end = data.end ?? null;
+	let category = data.category ?? null;
+	let start = data.start ?? null;
+	let end = data.end ?? null;
 </script>
 
 <section style="max-width: 1200px; margin: 0 auto; ">

--- a/src/routes/posts/+page.svelte
+++ b/src/routes/posts/+page.svelte
@@ -10,7 +10,7 @@
 </script>
 
 <section style="max-width: 1200px; margin: 0 auto; ">
-	<h3>Recent Articles without Alt Text</h3>
+	<h1>Recent Articles without Alt Text</h1>
 	<div
 		style="display: flex; flex-wrap: wrap; justify-content: center; align-items: center; gap: 3rem;"
 	>
@@ -83,6 +83,11 @@
 				<ImagePages images={parseContent(article.image, article.content)} />
 				<p>{article.date.split('T')[0]}</p>
 			</li>
+		{:else}
+			<div style="text-align: center">
+				<h2>No More Articles</h2>
+				<p>You've reached the end of the list!</p>
+			</div>
 		{/each}
 	</ul>
 </section>
@@ -118,7 +123,7 @@
 		border: 0.5px solid var(--text-color-theme);
 		background: var(--secondary-color-theme);
 	}
-	
+
 	#apply {
 		box-sizing: border-box;
 		padding: 0.75rem;

--- a/src/routes/posts/+page.svelte
+++ b/src/routes/posts/+page.svelte
@@ -3,10 +3,73 @@
 	import { parseContent } from '$lib/parse';
 
 	export let data;
+
+	$: category = data.category ?? null;
+	$: start = data.start ?? null;
+	$: end = data.end ?? null;
 </script>
 
 <section style="max-width: 1200px; margin: 0 auto; ">
 	<h3>Recent Articles without Alt Text</h3>
+	<div
+		style="display: flex; flex-wrap: wrap; justify-content: center; align-items: center; gap: 3rem;"
+	>
+		<div>
+			<label for="category">Select category:</label>
+			<select id="category" bind:value={category} on:selectionchange>
+				<option value={null}>All</option>
+				<option value={46}>News</option>
+				<option value={44}>Sports</option>
+				<option value={31}>Opinion</option>
+				<option value={5}>Arts</option>
+				<option value={55}>Statement</option>
+				<option value={32}>MiC</option>
+				<option value={124}>Photos</option>
+				<option value={24}>Podcasts</option>
+				<option value={10327}>Videos</option>
+			</select>
+		</div>
+		<div>
+			<label for="start"
+				>From
+				<input id="start" type="date" bind:value={start} />
+			</label>
+			<label for="end">
+				to
+				<input id="end" type="date" bind:value={end} />
+			</label>
+		</div>
+		<a
+			id="apply"
+			href={`posts?page=${data.page}
+				${category ? `&category=${category}` : ''}
+				${start ? `&start=${start}` : ''}
+				${end ? `&end=${end}` : ''}`}
+		>
+			Apply Filter
+		</a>
+	</div>
+
+	<nav
+		style="display: flex; justify-content: center; gap: 15px; padding: 1rem; font-size: 1.25rem;"
+	>
+		{#if data.page > 0}
+			<a
+				href={`/posts/?page=${data.page - 1}
+				${category ? `&category=${data.category}` : ''}
+				${start ? `&start=${data.start}` : ''}
+				${end ? `&end=${data.end}` : ''}`}>← Back</a
+			>
+		{/if}
+		{#if data.articles.length > 0}
+			<a
+				href={`/posts/?page=${data.page + 1}
+				${category ? `&category=${data.category}` : ''}
+				${start ? `&start=${data.start}` : ''}
+				${end ? `&end=${data.end}` : ''}`}>Next →</a
+			>
+		{/if}
+	</nav>
 	<ul>
 		{#each data.articles as article}
 			<li>
@@ -23,18 +86,50 @@
 		{/each}
 	</ul>
 </section>
-<footer
-	style="display: flex; justify-content: center; gap: 15px; padding: 1rem; font-size: 1.25rem;"
->
+<nav style="display: flex; justify-content: center; gap: 15px; padding: 1rem; font-size: 1.25rem;">
 	{#if data.page > 0}
-		<a href={`/posts/?page=${data.page - 1}`}>← Back</a>
+		<a
+			href={`/posts/?page=${data.page - 1}
+			${category ? `&category=${data.category}` : ''}
+			${start ? `&start=${data.start}` : ''}
+			${end ? `&end=${data.end}` : ''}`}>← Back</a
+		>
 	{/if}
 	{#if data.articles.length > 0}
-		<a href={`/posts/?page=${data.page + 1}`}>Next →</a>
+		<a
+			href={`/posts/?page=${data.page + 1}
+			${category ? `&category=${data.category}` : ''}
+			${start ? `&start=${data.start}` : ''}
+			${end ? `&end=${data.end}` : ''}`}>Next →</a
+		>
 	{/if}
-</footer>
+</nav>
 
 <style>
+	input,
+	select {
+		display: inline-block;
+		padding: 5px;
+
+		font-size: 16px;
+		width: 200px;
+
+		color: var(--text-color-theme);
+		border: 0.5px solid var(--text-color-theme);
+		background: var(--secondary-color-theme);
+	}
+	
+	#apply {
+		box-sizing: border-box;
+		padding: 0.75rem;
+
+		font-size: 1rem;
+		border: 1px solid var(--text-color-theme);
+
+		color: var(--text-color-theme);
+		background: var(--secondary-color-theme);
+	}
+
 	ul {
 		list-style: none;
 		display: grid;

--- a/src/routes/posts/+page.svelte
+++ b/src/routes/posts/+page.svelte
@@ -16,7 +16,7 @@
 	>
 		<div>
 			<label for="category">Select category:</label>
-			<select id="category" bind:value={category} on:selectionchange>
+			<select id="category" bind:value={category}>
 				<option value={null}>All</option>
 				<option value={46}>News</option>
 				<option value={44}>Sports</option>

--- a/worker/index.ts
+++ b/worker/index.ts
@@ -142,7 +142,7 @@ export default {
 					entry.date,
 					entry.images_published,
 					entry.images_published_with_alt_text,
-					entry.categories.toString(),
+					JSON.stringify(entry.categories),
 				)
 			);
 		});


### PR DESCRIPTION
Addresses one part of https://github.com/michigandaily/alt-text-tracker/issues/9

Adds a category filter and date range for the "track specific articles" page. These results are still paged - it could be worthwhile to find a way to navigate between pages more easily, such as inputting a page number or numerical buttons

The stacked bar chart is also now clickable, and redirects to the track articles page at the specific category and date. This is especially helpful for when there is a data point of interest that someone would like to see more details of, and can see the specific articles that require alt text for that date.
