### PR TITLE
Ignore row with duplicate primary key instead of updating

### DIFF
--- a/worker/index.ts
+++ b/worker/index.ts
@@ -127,7 +127,7 @@ export default {
 
 		// Batch insert/update all date entries
 		const stmt = env.DB.prepare(
-			`INSERT OR REPLACE INTO articles
+			`INSERT OR IGNORE INTO articles
 			(aid, date, images_published, images_published_with_alt_text, categories) VALUES
 			(?, ?, ?, ?, ?)`
 		);


### PR DESCRIPTION
When date_entries was still being used, it made sense to update a row with an existing date entry, since there might be new images/article data to add to each date. 
However, since we now fetch by articles, it's likely the data for individual articles won't change. In this case, I think ignoring these rows if a duplicate article id is encountered would be better. 