### PR TITLE
Limit initial data load to 31 days prior

### DIFF
--- a/src/lib/time.ts
+++ b/src/lib/time.ts
@@ -1,0 +1,5 @@
+export const lastWeek = new Date(new Date().getTime() - 7 * 24 * 60 * 60 * 1000);
+export const lastMonth = new Date(new Date().getTime() - 31 * 24 * 60 * 60 * 1000);
+export const lastSixMonths = new Date(new Date().getTime() - 31 * 24 * 60 * 60 * 1000 * 6);
+export const lastYear = new Date(new Date().getTime() - 365 * 24 * 60 * 60 * 1000);
+export const all = new Date('2022-12-31');

--- a/src/routes/+page.server.ts
+++ b/src/routes/+page.server.ts
@@ -1,12 +1,16 @@
 import type { PageServerLoad } from './$types';
 import type { ArticleEntry } from '$lib/types';
+import { lastMonth } from '$lib/time';
 
-export const load: PageServerLoad = async ({ platform }) => {
+export const load: PageServerLoad = async ({ platform, url }) => {
+	const after = url.searchParams.get('after') ??  lastMonth.toISOString().split('T')[0];
+
 	const resp = await platform?.env.DB.prepare(
-		'SELECT date, images_published, images_published_with_alt_text, categories FROM articles WHERE date > "2022-12-31" ORDER BY date ASC'
-	).all();
+		'SELECT date, images_published, images_published_with_alt_text, categories FROM articles WHERE date > ? ORDER BY date ASC'
+	).bind(after).all();
 
 	return {
-		entries: resp?.results as Array<ArticleEntry> | []
+		entries: resp?.results as Array<ArticleEntry> | [],
+		after 
 	};
 };


### PR DESCRIPTION
Closes https://github.com/michigandaily/alt-text-tracker/issues/30

Sets the default time range to the last month.
If the time range is changed, uses goto to set query params for the page. If the time range is larger than the data fetched so far, invalidate current data and reload.