### PR TITLE
Send slack reports after worker task

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ pnpm run dev -- --open
 
 Every day, the worker runs via a cron trigger and collects data on the previous day's usage of alt text.
 
-To test the scheduled worker, run `pnpm run worker`. You can go to http://localhost:8787/__scheduled` to trigger the worker task.
+To test the scheduled worker, run `pnpm run worker`. You can go to <http://localhost:8787/__scheduled> to trigger the worker task.
 
 To test daily slack notifications on the `alt-text-tracker` channel, create a .dev.vars file in the root of the directory, and add SLACK_WEBHOOK=\<your-webhook-here\>.
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Alt Text Tracker
 
-A dashboard for visualizing The Michigan Daily's alternative text on images published since January 2023. At the beginning of every day, a Cloudflare Worker runs and collects data on the previous day's images, both with and without alt text. 
+A dashboard for visualizing The Michigan Daily's alternative text on images published since January 2023. At the beginning of every day, a Cloudflare Worker runs and collects data on the previous day's images, both with and without alt text.
 
-The primary purpose of this project is intended to be used as an accessibility auditor for the editorial staff of The Michigan Daily. 
+The primary purpose of this project is intended to be used as an accessibility auditor for the editorial staff of The Michigan Daily.
 
 ## Developing
 
@@ -18,6 +18,14 @@ pnpm run dev
 # or start the server and open the app in a new browser tab
 pnpm run dev -- --open
 ```
+
+## Worker
+
+Every day, the worker runs via a cron trigger and collects data on the previous day's usage of alt text.
+
+To test the scheduled worker, run `pnpm run worker`. You can go to http://localhost:8787/__scheduled` to trigger the worker task.
+
+To test daily slack notifications on the `alt-text-tracker` channel, create a .dev.vars file in the root of the directory, and add SLACK_WEBHOOK=\<your-webhook-here\>.
 
 ## Building
 

--- a/README.md
+++ b/README.md
@@ -27,12 +27,6 @@ To test the scheduled worker, run `pnpm run worker`. You can go to <http://local
 
 To test daily slack notifications on the `alt-text-tracker` channel, create a .dev.vars file in the root of the directory, and add SLACK_WEBHOOK=\<your-webhook-here\>.
 
-## Building
+## Deployment
 
-To create a production version of your app:
-
-```bash
-pnpm run build
-```
-
-You can preview the production build with `pnpm run preview`.
+To deploy changes to the worker, run `npx wrangler deploy`. To change or add a new webhook or secret environment variable, run `npx wrangler secret put <KEY>`.

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
 	"version": "0.0.1",
 	"private": true,
 	"scripts": {
-		"worker": "npx wrangler dev --test-scheduled",
+		"worker": "npx wrangler dev --env local --test-scheduled",
 		"init": "./bin/init",
 		"update": "./bin/update",
 		"clear": "./bin/clear",

--- a/worker/index.ts
+++ b/worker/index.ts
@@ -12,27 +12,62 @@
  * Learn more at https://developers.cloudflare.com/workers/
  */
 
-import type { Article, Block, Image, ArticleEntry, PostsQuery } from './types';
+import type { Article, Block, Image, ArticleEntry, PostsQuery, SlackBlock } from './types';
 
-function parseImageData(
-	aid: number,
-	image: Image,
-	image_data: Record<string, ArticleEntry>
-) {
-	image_data[aid].images_published += 1;
+function getAttachment(date: string, today: string, image_data: Record<string, ArticleEntry>) {
+	const data_all = Object.values(image_data).filter((a) => a.date === date);
+	const data_without_alt_text = data_all.filter(
+		(a) => a.images_published !== a.images_published_with_alt_text
+	);
 
-	// If image contains alt text, add to images with alt text count, as well as the corresponding
-	// category specific counts
-	if (image && image.alt && image.alt.length > 0) {
-		image_data[aid].images_published_with_alt_text += 1;
-	} 
+	if (data_all.length === 0) {
+		return false;
+	}
+
+	const attachment: { color: string; blocks: Array<SlackBlock> } = {
+		color: data_without_alt_text.length === 0 ? '#90EE90' : '#FF6347',
+		blocks: [
+			{
+				type: 'section',
+				text: {
+					type: 'mrkdwn',
+					text: `*On <https://michigan-daily-alt-text-tracker.pages.dev/posts/?start=${date}&end=${date}|${new Date(date).toLocaleDateString('en-us', { weekday: 'long', year: 'numeric', month: 'short', day: 'numeric' })}>*\n📝 *${data_all.length}* articles were published. Of those, *${data_without_alt_text.length}* articles are in need of alternative text.\n🖼️ *${data_all.reduce((sum, a) => sum + a.images_published, 0)}* images were published. Of those, *${data_without_alt_text.reduce((sum, a) => sum + a.images_published, 0)}* images are in need of alternative text.`
+				}
+			}
+		]
+	};
+
+	if (date === today) {
+		attachment.blocks.push({
+			type: 'context',
+			elements: [
+				{
+					type: 'mrkdwn',
+					text: `_Note: Incomplete data. Wait for tomorrow for a full report on today's alt text._`
+				}
+			]
+		},
+		{
+			type: 'divider'
+		});
+	} else {
+		attachment.blocks.push({
+			type: 'divider'
+		});
+	}
+
+	return attachment;
 }
 
-function parseBlockData(
-	aid: number,
-	block: Block,
-	image_data: Record<string, ArticleEntry>
-) {
+function parseImageData(aid: number, image: Image, image_data: Record<string, ArticleEntry>) {
+	image_data[aid].images_published += 1;
+
+	if (image && image.alt && image.alt.length > 0) {
+		image_data[aid].images_published_with_alt_text += 1;
+	}
+}
+
+function parseBlockData(aid: number, block: Block, image_data: Record<string, ArticleEntry>) {
 	if (block.blockName == 'core/image' && !Array.isArray(block.data)) {
 		parseImageData(aid, block.data, image_data);
 	} else if (block.blockName == 'core/gallery') {
@@ -52,7 +87,11 @@ function parseBlockData(
 		block.data.forEach((image: Image) => {
 			parseImageData(aid, image, image_data);
 		});
-	} else if (block.blockName == 'core/columns' || block.blockName == 'core/column' || block.blockName == 'core/group') {
+	} else if (
+		block.blockName == 'core/columns' ||
+		block.blockName == 'core/column' ||
+		block.blockName == 'core/group'
+	) {
 		block.innerBlocks.forEach((block) => parseBlockData(aid, block, image_data));
 	}
 }
@@ -64,8 +103,8 @@ function parseArticleData(post: Article, image_data: Record<string, ArticleEntry
 		date,
 		images_published: 0,
 		images_published_with_alt_text: 0,
-		categories: post.categories,
-	}
+		categories: post.categories
+	};
 
 	// Add featured image data
 	parseImageData(post.id, post.image, image_data);
@@ -76,7 +115,11 @@ function parseArticleData(post: Article, image_data: Record<string, ArticleEntry
 	});
 }
 
-async function parsePostQuery(page: number, after: string, image_data: Record<string, ArticleEntry>) {
+async function parsePostQuery(
+	page: number,
+	after: string,
+	image_data: Record<string, ArticleEntry>
+) {
 	let total_pages: number = 1;
 	await fetch(
 		`https://www.michigandaily.com/wp-json/tmd/v1/posts_query/?num_posts=200&page=${page}&after=${after}`
@@ -104,6 +147,8 @@ async function parsePostQuery(page: number, after: string, image_data: Record<st
 
 export interface Env {
 	DB: D1Database;
+	PRODUCTION: boolean;
+	SLACK_WEBHOOK: string;
 }
 
 export default {
@@ -120,7 +165,7 @@ export default {
 		const after: string = DB_resp ? DB_resp['MAX(date)'] ?? '2022-12-31' : '2022-12-31';
 
 		const total_pages = await parsePostQuery(0, after, image_data);
-		
+
 		for (let i = 1; i < total_pages; ++i) {
 			await parsePostQuery(i, after, image_data);
 		}
@@ -142,12 +187,46 @@ export default {
 					entry.date,
 					entry.images_published,
 					entry.images_published_with_alt_text,
-					JSON.stringify(entry.categories),
+					JSON.stringify(entry.categories)
 				)
 			);
 		});
 
 		const info = await env.DB.batch(batchUpdate);
+
+		if (env.PRODUCTION) {
+			const [today] = new Date().toISOString().split('T');
+			const [yesterday] = new Date(new Date().getTime() - 24 * 60 * 60 * 1000)
+				.toISOString()
+				.split('T');
+
+			const dates = [yesterday, today];
+			const attachments = dates.map((date) => getAttachment(date, today, image_data)).filter((field) => field);
+
+			const resp = await fetch(env.SLACK_WEBHOOK, {
+				method: 'POST',
+				body: JSON.stringify({
+					blocks: [
+						{
+							type: 'header',
+							text: {
+								type: 'plain_text',
+								text: `Daily Report - ${today}`
+							}
+						}
+					],
+					attachments
+				}),
+				headers: { 'Content-Type': 'application/json' }
+			})
+				.then((resp) => resp.text())
+				.catch((error) => {
+					console.error(error);
+				});
+
+			console.log(resp);
+		}
+
 		console.log(info);
 	}
 };

--- a/worker/index.ts
+++ b/worker/index.ts
@@ -14,7 +14,7 @@
 
 import type { Article, Block, Image, ArticleEntry, PostsQuery, SlackBlock } from './types';
 
-function getAttachment(date: string, today: string, image_data: Record<string, ArticleEntry>) {
+function formatAttachment(date: string, today: string, image_data: Record<string, ArticleEntry>) {
 	const data_all = Object.values(image_data).filter((a) => a.date === date);
 	const data_without_alt_text = data_all.filter(
 		(a) => a.images_published !== a.images_published_with_alt_text
@@ -38,18 +38,20 @@ function getAttachment(date: string, today: string, image_data: Record<string, A
 	};
 
 	if (date === today) {
-		attachment.blocks.push({
-			type: 'context',
-			elements: [
-				{
-					type: 'mrkdwn',
-					text: `_Note: Incomplete data. Wait for tomorrow for a full report on today's alt text._`
-				}
-			]
-		},
-		{
-			type: 'divider'
-		});
+		attachment.blocks.push(
+			{
+				type: 'context',
+				elements: [
+					{
+						type: 'mrkdwn',
+						text: `_Note: Incomplete data. Wait for tomorrow for a full report on today's alt text._`
+					}
+				]
+			},
+			{
+				type: 'divider'
+			}
+		);
 	} else {
 		attachment.blocks.push({
 			type: 'divider'
@@ -201,8 +203,6 @@ export default {
 				.split('T');
 
 			const dates = [yesterday, today];
-			const attachments = dates.map((date) => getAttachment(date, today, image_data)).filter((field) => field);
-
 			const resp = await fetch(env.SLACK_WEBHOOK, {
 				method: 'POST',
 				body: JSON.stringify({
@@ -215,7 +215,9 @@ export default {
 							}
 						}
 					],
-					attachments
+					attachments: dates
+						.map((date) => formatAttachment(date, today, image_data))
+						.filter((field) => field)
 				}),
 				headers: { 'Content-Type': 'application/json' }
 			})

--- a/worker/messaging.ts
+++ b/worker/messaging.ts
@@ -1,0 +1,117 @@
+import type { ArticleEntry } from './types';
+
+export async function sendReport(
+	url: string,
+	options: { date: string; data: Record<string, ArticleEntry> }
+) {
+	const blocks = formatBlock(options.date, options.data);
+	const attachments = formatAttachment(options.date, options.data);
+
+	const body = blocks ? { blocks, attachments } : { attachments };
+
+	if (attachments) {
+		const resp = await fetch(url, {
+			method: 'POST',
+			body: JSON.stringify(body),
+			headers: { 'Content-Type': 'application/json' }
+		})
+			.then((resp) => resp.text())
+			.catch((error) => {
+				return error;
+			});
+
+		return resp;
+	}
+	return JSON.stringify({ message: 'No data found.' });
+}
+
+function formatBlock(date: string, data: Record<string, ArticleEntry>) {
+	const data_all = Object.values(data).filter((a) => a.date === date);
+	const data_without_alt_text = data_all.filter(
+		(a) => a.images_published !== a.images_published_with_alt_text
+	);
+	const images_without_alt_text = data_without_alt_text.reduce(
+		(sum, a) => sum + a.images_published,
+		0
+	);
+
+	if (images_without_alt_text <= 20) {
+		return false;
+	}
+
+	return [
+		{
+			type: 'section',
+			text: {
+				type: 'mrkdwn',
+				text: `<!channel> ⚠️ *Action Recommended:* More than 20 images from <!date^${(new Date(date).getTime() + 5 * 60 * 60 * 1000) / 1000}^{date_pretty}|${date}> do not have alt text.`
+			}
+		}
+	];
+}
+
+function formatAttachment(date: string, data: Record<string, ArticleEntry>) {
+	const data_all = Object.values(data).filter((a) => a.date === date);
+	const data_without_alt_text = data_all.filter(
+		(a) => a.images_published !== a.images_published_with_alt_text
+	);
+	const images_without_alt_text = data_without_alt_text.reduce(
+		(sum, a) => sum + a.images_published,
+		0
+	);
+
+	if (data_all.length === 0) {
+		return false;
+	}
+
+	return [
+		{
+			color:
+				images_without_alt_text === 0
+					? '#90EE90'
+					: images_without_alt_text < 5
+						? '#FFDC73'
+						: images_without_alt_text < 10
+							? '#FFA500'
+							: '#FF6347',
+			blocks: [
+				{
+					type: 'section',
+					text: {
+						type: 'mrkdwn',
+						text: `*On <https://michigan-daily-alt-text-tracker.pages.dev/posts/?start=${date}&end=${date}|${new Date(
+							new Date(date).getTime() +
+							5 * 60 * 60 * 1000
+						).toLocaleDateString('en-us', {
+							weekday: 'long',
+							year: 'numeric',
+							month: 'long',
+							day: 'numeric'
+						})}>*`
+					}
+				},
+				{
+					type: 'section',
+					text: {
+						type: 'mrkdwn',
+						text:
+							`📝 *${data_all.length}* articles were published. Of those, *${data_without_alt_text.length}* articles are in need of alternative text.` +
+							`\n🖼️ *${data_all.reduce((sum, a) => sum + a.images_published, 0)}* images were published. Of those, *${images_without_alt_text}* images are in need of alternative text.`
+					}
+				},
+				{
+					type: 'context',
+					elements: [
+						{
+							type: 'mrkdwn',
+							text: `_See more insights at https://michigan-daily-alt-text-tracker.pages.dev_`
+						}
+					]
+				},
+				{
+					type: 'divider'
+				}
+			]
+		}
+	];
+}

--- a/worker/messaging.ts
+++ b/worker/messaging.ts
@@ -55,6 +55,8 @@ function formatAttachment(date: string, data: Record<string, ArticleEntry>) {
 	const data_without_alt_text = data_all.filter(
 		(a) => a.images_published !== a.images_published_with_alt_text
 	);
+
+	const images_all = data_all.reduce((sum, a) => sum + a.images_published, 0);
 	const images_without_alt_text = data_without_alt_text.reduce(
 		(sum, a) => sum + a.images_published,
 		0
@@ -95,8 +97,8 @@ function formatAttachment(date: string, data: Record<string, ArticleEntry>) {
 					text: {
 						type: 'mrkdwn',
 						text:
-							`📝 *${data_all.length}* articles were published. Of those, *${data_without_alt_text.length}* articles are in need of alternative text.` +
-							`\n🖼️ *${data_all.reduce((sum, a) => sum + a.images_published, 0)}* images were published. Of those, *${images_without_alt_text}* images are in need of alternative text.`
+							`📝 *${data_all.length}* article${data_all.length !== 1 ? 's were' : ' was'} published. Of those, *${data_without_alt_text.length}* article${data_without_alt_text.length !== 1 ? 's are' : ' is'} in need of alternative text.` +
+							`\n🖼️ *${images_all}* image${images_all !== 1 ? 's were' : ' was'} published. Of those, *${images_without_alt_text}* image${images_without_alt_text !== 1 ? 's are' : ' is'} in need of alternative text.`
 					}
 				},
 				{

--- a/worker/types.ts
+++ b/worker/types.ts
@@ -29,6 +29,18 @@ export interface Image {
 	alt: string;
 }
 
+export interface SlackBlock {
+	type: string;
+	text?: {
+		type: string;
+		text: string;
+	}
+	elements?: [{
+		type: string;
+		text?: string;
+	}]
+}
+
 export interface ArticleEntry {
 	date: string;
 	images_published: number;

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -12,7 +12,7 @@ PRODUCTION = true
 # Docs: https://developers.cloudflare.com/workers/platform/triggers/cron-triggers/
 # Configuration: https://developers.cloudflare.com/workers/wrangler/configuration/#triggers
 [triggers]
-crons = ["0 0 * * *"] # 0 0 * * * = run at the beginning of every day
+crons = ["0 16 * * *"] # 0 0 * * * = run in the middle of the day
 
 [[d1_databases]]
 binding = "DB" # available in your Worker on env.DB

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -2,6 +2,12 @@ name = "michigan-daily-alt-text-tracker"
 main = "worker/index.ts"
 compatibility_date = "2024-02-23"
 
+[vars]
+PRODUCTION = false
+
+[env.production.vars]
+PRODUCTION = true
+
 # Cron Triggers
 # Docs: https://developers.cloudflare.com/workers/platform/triggers/cron-triggers/
 # Configuration: https://developers.cloudflare.com/workers/wrangler/configuration/#triggers

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -3,19 +3,25 @@ main = "worker/index.ts"
 compatibility_date = "2024-02-23"
 
 [vars]
+PRODUCTION = true
+
+[[d1_databases]]
+binding = "DB"                                       
+database_name = "michigan-daily-alt-text-tracker"
+database_id = "90d3113e-ddda-4ab7-b7a3-d87ca2cf86e4"
+preview_database_id = "DB"      
+
+[env.local.vars]
 PRODUCTION = false
 
-[env.production.vars]
-PRODUCTION = true
+[[env.local.d1_databases]]
+binding = "DB"                                       
+database_name = "michigan-daily-alt-text-tracker"
+database_id = "90d3113e-ddda-4ab7-b7a3-d87ca2cf86e4"
+preview_database_id = "DB"      
 
 # Cron Triggers
 # Docs: https://developers.cloudflare.com/workers/platform/triggers/cron-triggers/
 # Configuration: https://developers.cloudflare.com/workers/wrangler/configuration/#triggers
 [triggers]
-crons = ["0 16 * * *"] # 0 0 * * * = run in the middle of the day
-
-[[d1_databases]]
-binding = "DB" # available in your Worker on env.DB
-database_name = "michigan-daily-alt-text-tracker"
-database_id = "90d3113e-ddda-4ab7-b7a3-d87ca2cf86e4"
-preview_database_id = "DB" # Required for Pages local development
+crons = ["0 16 * * *"] # 0 0 * * * = run in the middle of the day                    


### PR DESCRIPTION
Sends a daily slack report after worker runs. 
Only reports data on the current day and day before. 

Currently thinking about:
- Investigating if it's possible to ping the channel when the amount of images without alt text reaches a numerical threshold
- Reorganizing worker code to increase positive vibes
- Maybe only send data from yesterday, and move cron trigger closer to morning/midday 