### PR TITLE
Fix improper category attribution

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -20,7 +20,7 @@
 
 	$: tidy = entries.filter(
 		(entry) =>
-			new Date(entry.date) >= timerange && (category ? entry.categories.includes(category) : true)
+			new Date(entry.date) >= timerange && (category ? JSON.parse(entry.categories).includes(category) : true)
 	);
 
 	$: index = d3.rollup(


### PR DESCRIPTION
- Fixes https://github.com/michigandaily/alt-text-tracker/issues/39

Whoopsies, it turns out I was separating categories from the charts based on substring. This probably caused certain articles to be improperly attributed to certain categories. An example is opinion being framed by focal point for having lots of articles without alt text:  

Before:
<img width="1422" alt="Screenshot 2024-04-08 at 2 18 03 PM" src="https://github.com/michigandaily/alt-text-tracker/assets/93745470/bf68197a-b02f-48cc-84a4-cdeec17de5d4">

After:
<img width="1406" alt="Screenshot 2024-04-08 at 2 16 47 PM" src="https://github.com/michigandaily/alt-text-tracker/assets/93745470/82a7ece6-12af-48af-9aef-3ab301cc2216">

With the link for that day for opinion being: 
https://michigan-daily-alt-text-tracker.pages.dev/posts?category=31&start=2023-06-07&end=2023-06-07

While without category filter, we see that the articles are actually from focal point: 
https://michigan-daily-alt-text-tracker.pages.dev/posts?page=0&start=2023-06-07&end=2023-06-07

It's probably because certain category ids are substrings of other category ids? Seems to show properly for categories now.