### PR TITLE
Fix article time

### DIFF
--- a/src/lib/components/articlecard.svelte
+++ b/src/lib/components/articlecard.svelte
@@ -37,7 +37,7 @@
 		by {parseAuthors(article.authors)}
 	</p>
 	<time datetime={article.date} class="subtitle">
-		{formatISODate(article.date.split('T')[0], {
+		{formatISODate(article.date, {
 			weekday: undefined,
 			month: 'long',
 			year: 'numeric',

--- a/src/lib/components/articlecard.svelte
+++ b/src/lib/components/articlecard.svelte
@@ -37,7 +37,7 @@
 		by {parseAuthors(article.authors)}
 	</p>
 	<time datetime={article.date} class="subtitle">
-		{formatISODate(article.date, {
+		{formatISODate(article.date.split('T')[0], {
 			weekday: undefined,
 			month: 'long',
 			year: 'numeric',

--- a/src/lib/time.ts
+++ b/src/lib/time.ts
@@ -7,7 +7,8 @@ export const lastYear = new Date(new Date().getTime() - 365 * 24 * 60 * 60 * 100
 export const all = new Date('2022-12-31');
 
 export function formatISODate(date: string, { weekday, year, month, day }: DateStringOptions) {
-	return new Date(new Date(date).getTime() + 5 * 60 * 60 * 1000).toLocaleDateString('en-us', {
+	return new Date(date).toLocaleDateString('en-us', {
+		timeZone: "UTC",
 		weekday,
 		year,
 		month,

--- a/src/lib/time.ts
+++ b/src/lib/time.ts
@@ -7,7 +7,7 @@ export const lastYear = new Date(new Date().getTime() - 365 * 24 * 60 * 60 * 100
 export const all = new Date('2022-12-31');
 
 export function formatISODate(date: string, { weekday, year, month, day }: DateStringOptions) {
-	return new Date(new Date(date).getTime() + 5 * 60 * 60 * 1000).toLocaleDateString('en-us', {
+	return new Date(new Date(date).getTime() + 4 * 60 * 60 * 1000).toLocaleDateString('en-us', {
 		weekday,
 		year,
 		month,

--- a/src/lib/time.ts
+++ b/src/lib/time.ts
@@ -7,7 +7,7 @@ export const lastYear = new Date(new Date().getTime() - 365 * 24 * 60 * 60 * 100
 export const all = new Date('2022-12-31');
 
 export function formatISODate(date: string, { weekday, year, month, day }: DateStringOptions) {
-	return new Date(new Date(date).getTime() + 4 * 60 * 60 * 1000).toLocaleDateString('en-us', {
+	return new Date(new Date(date).getTime() + 5 * 60 * 60 * 1000).toLocaleDateString('en-us', {
 		weekday,
 		year,
 		month,


### PR DESCRIPTION
- Fixes https://github.com/michigandaily/alt-text-tracker/issues/43

First tried removing the time conversion entirely, but this made other articles one day early. I think this is because they are published closer to the beginning of the day, meaning earlier in EST time. 

I think this is happening because of daylights savings. Usually EST to UTC involves a 5 hour time difference, so the formatISODate function adds 5 hours to the date. But since the specific article is published close to the beginning of the next day and we currently have a 4 hour time difference instead, it's being converted into the next day. Ew.

For now, stripping away the hours and assuming each article is published at the beginning of the day works. Ew. The vibes are terrible here.