### PR TITLE
(WIP) Cache delete endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,24 +8,30 @@ The primary purpose of this project is intended to be used as an accessibility a
 
 Install dependencies with `pnpm install`
 
-To set up the local database, run `pnpm run init`. It may take a minute to fetch all the data.
+To set up the local database, run `pnpm init`. It may take a minute to fetch all the data.
 
 Then, to open your local development environment, run
 
 ```bash
-pnpm run dev
+pnpm dev
 
 # or start the server and open the app in a new browser tab
-pnpm run dev -- --open
+pnpm dev -- --open
 ```
 
 ## Worker
 
 Every day, the worker runs via a cron trigger and collects data on the previous day's usage of alt text.
 
-To test the scheduled worker, run `pnpm run worker`. You can go to <http://localhost:8787/__scheduled> to trigger the worker task.
+To test the scheduled worker, run `pnpm worker`. You can go to <http://localhost:8787/__scheduled> to trigger the worker task.
 
 To test daily slack notifications on the `alt-text-tracker` channel, create a .dev.vars file in the root of the directory, and add SLACK_WEBHOOK=\<your-webhook-here\>.
+
+## Cache
+
+Database reads are cached upon arrival on the main page, and are invalidated when the worker runs or after 24 hours.
+
+Caching is not emulated on a development environment. To test the page with cache emulation, run `pnpm emulate`. Every time a change is made, you may have to wait a few seconds for SvelteKit to rebuild.
 
 ## Deployment
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
 	"private": true,
 	"scripts": {
 		"worker": "npx wrangler dev --env local --test-scheduled",
-		"emulate": "vite build -w & npx wrangler pages dev .svelte-kit/cloudflare --live-reload --local --d1 DB=DB",
+		"emulate": "vite build -w & npx wrangler pages dev .svelte-kit/cloudflare --live-reload --local --binding PRODUCTION=false --d1 DB=DB",
 		"init": "./bin/init",
 		"update": "./bin/update",
 		"clear": "./bin/clear",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
 	"private": true,
 	"scripts": {
 		"worker": "npx wrangler dev --env local --test-scheduled",
+		"emulate": "vite build -w & npx wrangler pages dev .svelte-kit/cloudflare --live-reload --local --d1 DB=DB",
 		"init": "./bin/init",
 		"update": "./bin/update",
 		"clear": "./bin/clear",

--- a/src/app.d.ts
+++ b/src/app.d.ts
@@ -8,6 +8,7 @@ declare global {
 		interface Platform {
 			env: {
 				DB: D1Database;
+				PRODUCTION: string;
 			};
 			context: {
 				waitUntil(promise: Promise<unknown>): void;

--- a/src/app.d.ts
+++ b/src/app.d.ts
@@ -8,6 +8,7 @@ declare global {
 		interface Platform {
 			env: {
 				DB: D1Database;
+				CACHEKEY: string;
 				PRODUCTION: string;
 			};
 			context: {

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -1,0 +1,17 @@
+export const D1CacheName = "d1-michigan-daily-alt-text-tracker";
+
+export const cachePut = async (url: URL, cache: Cache, response: D1Result<Record<string, unknown>>) => {
+    const entry = new Response(JSON.stringify(response.results));
+	entry.headers.append('Cache-Control', 's-maxage=86400');
+
+    await cache.put(url, entry);
+    console.log("Populated cache")
+}
+
+export const cacheGet = async (url: URL, cache: Cache) => {
+    const response = await cache.match(url);
+    const entry = await response?.json();
+    console.log("Retrieving from cache")
+
+    return entry;
+}

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -1,17 +1,22 @@
-export const D1CacheName = "d1-michigan-daily-alt-text-tracker";
+import type { CacheResponse } from './types';
 
-export const cachePut = async (url: URL, cache: Cache, response: D1Result<Record<string, unknown>>) => {
-    const entry = new Response(JSON.stringify(response.results));
+export const D1CacheName = 'd1-michigan-daily-alt-text-tracker';
+export const url = 'https://michigan-daily-alt-text-tracker.pages.dev';
+
+export const cachePut = async (url: URL | string, cache: Cache, response: CacheResponse) => {
+	const entry = new Response(JSON.stringify(response));
 	entry.headers.append('Cache-Control', 's-maxage=86400');
 
-    await cache.put(url, entry);
-    console.log("Populated cache")
-}
+	await cache.put(url, entry);
+};
 
-export const cacheGet = async (url: URL, cache: Cache) => {
-    const response = await cache.match(url);
-    const entry = await response?.json();
-    console.log("Retrieving from cache")
+export const cacheGet = async (url: URL | string, cache: Cache) => {
+	const response = await cache.match(url);
+	const entry = await response?.json();
 
-    return entry;
-}
+	return entry;
+};
+
+export const cacheInvalidate = async (urls: (URL | string)[], cache: Cache) => {
+	return Promise.all(urls.map((url) => cache.delete(url))).then((status) => status);
+};

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -1,3 +1,4 @@
+import { secondsBeforeCronTrigger } from './time';
 import type { CacheResponse } from './types';
 
 export const D1CacheName = 'd1-michigan-daily-alt-text-tracker';
@@ -5,7 +6,7 @@ export const url = 'https://michigan-daily-alt-text-tracker.pages.dev';
 
 export const cachePut = async (url: URL | string, cache: Cache, response: CacheResponse) => {
 	const entry = new Response(JSON.stringify(response));
-	entry.headers.append('Cache-Control', 's-maxage=86400');
+	entry.headers.append('Cache-Control', `s-maxage=${secondsBeforeCronTrigger()}`);
 
 	await cache.put(url, entry);
 };

--- a/src/lib/time.ts
+++ b/src/lib/time.ts
@@ -1,14 +1,15 @@
-import type { DateStringOptions } from "./types";
-
 export const lastWeek = new Date(new Date().getTime() - 7 * 24 * 60 * 60 * 1000);
 export const lastMonth = new Date(new Date().getTime() - 31 * 24 * 60 * 60 * 1000);
 export const lastSixMonths = new Date(new Date().getTime() - 31 * 24 * 60 * 60 * 1000 * 6);
 export const lastYear = new Date(new Date().getTime() - 365 * 24 * 60 * 60 * 1000);
 export const all = new Date('2022-12-31');
 
-export function formatISODate(date: string, { weekday, year, month, day }: DateStringOptions) {
+export function formatISODate(
+	date: string,
+	{ weekday, year, month, day }: Intl.DateTimeFormatOptions
+) {
 	return new Date(date).toLocaleDateString('en-us', {
-		timeZone: "UTC",
+		timeZone: 'UTC',
 		weekday,
 		year,
 		month,

--- a/src/lib/time.ts
+++ b/src/lib/time.ts
@@ -16,3 +16,10 @@ export function formatISODate(
 		day
 	});
 }
+
+export function secondsBeforeCronTrigger() {
+	const date = new Date();
+	if (date.getUTCHours() >= 16) date.setUTCDate(date.getUTCDate() + 1)
+	date.setUTCHours(16, 1, 0, 0);
+	return (date.getTime() - new Date().getTime()) / 1000;
+}

--- a/src/lib/types.d.ts
+++ b/src/lib/types.d.ts
@@ -42,9 +42,8 @@ export interface Block {
 	innerBlocks: Array<Block>;
 }
 
-interface DateStringOptions {
-	weekday: 'long' | 'short' | 'narrow' | undefined;
-	year: 'numeric' | '2-digit' | undefined;
-	month: 'long' | 'short' | 'narrow' | 'numeric' | '2-digit' | undefined;
-	day: 'numeric' | '2-digit' | undefined;
+export interface CacheResponse {
+	entries: ArticleEntry[];
+	after?: string;
+	before?: string;
 }

--- a/src/routes/+page.server.ts
+++ b/src/routes/+page.server.ts
@@ -1,16 +1,41 @@
 import type { PageServerLoad } from './$types';
 import type { ArticleEntry } from '$lib/types';
 import { lastMonth } from '$lib/time';
+import { error } from '@sveltejs/kit';
 
 export const load: PageServerLoad = async ({ platform, url }) => {
-	const after = url.searchParams.get('after') ??  lastMonth.toISOString().split('T')[0];
+	const after = url.searchParams.get('after') ?? lastMonth.toISOString().split('T')[0];
 
-	const resp = await platform?.env.DB.prepare(
+	if (platform === undefined) {
+		error(404, { message: 'Platform is undefined' });
+	}
+
+	const cache = platform.caches.default;
+
+	const cacheResp = await cache.match(url);
+	const entries = await cacheResp?.json();
+
+	if (entries) {
+		console.log("Returning without entries:", entries)
+		return {
+			entries: [],
+			after
+		};
+	}
+
+	const resp = await platform.env.DB.prepare(
 		'SELECT date, images_published, images_published_with_alt_text, categories FROM articles WHERE date > ?'
-	).bind(after).all();
+	)
+		.bind(after)
+		.all();
+
+	const cacheEntry = new Response(JSON.stringify(resp.results));
+	cacheEntry.headers.append('Cache-Control', 's-maxage=100');
+
+	await cache.put(url, cacheEntry);
 
 	return {
 		entries: resp?.results as Array<ArticleEntry> | [],
-		after 
+		after
 	};
 };

--- a/src/routes/+page.server.ts
+++ b/src/routes/+page.server.ts
@@ -1,30 +1,41 @@
 import type { PageServerLoad } from './$types';
+
+import { D1CacheName, cacheGet, cachePut} from '$lib/storage';
 import type { ArticleEntry } from '$lib/types';
 import { lastMonth } from '$lib/time';
+
 import { error } from '@sveltejs/kit';
 
 export const load: PageServerLoad = async ({ platform, url }) => {
-	const after = url.searchParams.get('after') ?? lastMonth.toISOString().split('T')[0];
-
 	if (platform === undefined) {
 		error(404, { message: 'Platform is undefined' });
 	}
 
-	const cache = platform.caches.default;
+	const after = url.searchParams.get('after') ?? lastMonth.toISOString().split('T')[0];
+	const cache = await platform.caches.open(D1CacheName);
 
-	const resp = await platform.env.DB.prepare(
+	const entries = await cacheGet(url, cache);
+	if (entries) {
+		return {
+			entries,
+			after
+		};
+	}
+
+	const response = await platform.env.DB.prepare(
 		'SELECT date, images_published, images_published_with_alt_text, categories FROM articles WHERE date > ?'
 	)
 		.bind(after)
 		.all();
 
-	const cacheEntry = new Response(JSON.stringify(resp.results));
-	cacheEntry.headers.append('Cache-Control', 's-maxage=10');
+	if (response.error) {
+		error(400, { message: response.error });
+	}
 
-	await cache.put(url, cacheEntry);
+	await cachePut(url, cache, response);
 
 	return {
-		entries: resp?.results as Array<ArticleEntry> | [],
+		entries: response.results as Array<ArticleEntry> | [],
 		after
 	};
 };

--- a/src/routes/+page.server.ts
+++ b/src/routes/+page.server.ts
@@ -12,17 +12,6 @@ export const load: PageServerLoad = async ({ platform, url }) => {
 
 	const cache = platform.caches.default;
 
-	const cacheResp = await cache.match(url);
-	const entries = await cacheResp?.json();
-
-	if (entries) {
-		console.log("Returning without entries:", entries)
-		return {
-			entries: [],
-			after
-		};
-	}
-
 	const resp = await platform.env.DB.prepare(
 		'SELECT date, images_published, images_published_with_alt_text, categories FROM articles WHERE date > ?'
 	)
@@ -30,7 +19,7 @@ export const load: PageServerLoad = async ({ platform, url }) => {
 		.all();
 
 	const cacheEntry = new Response(JSON.stringify(resp.results));
-	cacheEntry.headers.append('Cache-Control', 's-maxage=100');
+	cacheEntry.headers.append('Cache-Control', 's-maxage=10');
 
 	await cache.put(url, cacheEntry);
 

--- a/src/routes/+page.server.ts
+++ b/src/routes/+page.server.ts
@@ -14,11 +14,12 @@ export const load: PageServerLoad = async ({ platform, url }) => {
 	const after = url.searchParams.get('after') ?? lastMonth.toISOString().split('T')[0];
 	const cache = await platform.caches.open(D1CacheName);
 
-	const entries = await cacheGet(url, cache);
+	const entries = await cacheGet(url, cache) as ArticleEntry[];
 	if (entries) {
 		return {
 			entries,
-			after
+			after,
+			cached: true,
 		};
 	}
 
@@ -35,7 +36,8 @@ export const load: PageServerLoad = async ({ platform, url }) => {
 	await cachePut(url, cache, response);
 
 	return {
-		entries: response.results as Array<ArticleEntry> | [],
-		after
+		entries: response.results as ArticleEntry[] | [],
+		after,
+		cached: false
 	};
 };

--- a/src/routes/+page.server.ts
+++ b/src/routes/+page.server.ts
@@ -20,8 +20,7 @@ export const load: PageServerLoad = async ({ platform, url }) => {
 		return {
 			entries: cacheEntry.entries,
 			after,
-			cached: true,
-			origin: url.origin,
+			cached: true
 		};
 	}
 
@@ -45,7 +44,6 @@ export const load: PageServerLoad = async ({ platform, url }) => {
 	return {
 		entries: response.results as ArticleEntry[] | [],
 		after,
-		cached: false,
-		origin: url.origin,
+		cached: false
 	};
 };

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -8,6 +8,7 @@
 	import { lastWeek, lastMonth, lastSixMonths, lastYear, all } from '$lib/time.js';
 
 	export let data;
+	$: console.log("D1 Cached Status:", data.cached);
 	$: entries = data?.entries;
 
 	let timerange = data.after ? new Date(data.after) : lastMonth;
@@ -20,7 +21,8 @@
 
 	$: tidy = entries.filter(
 		(entry) =>
-			new Date(entry.date) >= timerange && (category ? JSON.parse(entry.categories).includes(category) : true)
+			new Date(entry.date) >= timerange &&
+			(category ? JSON.parse(entry.categories).includes(category) : true)
 	);
 
 	$: index = d3.rollup(

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -9,7 +9,6 @@
 
 	export let data;
 	$: console.log("D1 Cached Status:", data.cached);
-	$: console.log("URL origin: ", data.origin)
 
 	$: entries = data.entries;
 

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -9,7 +9,8 @@
 
 	export let data;
 	$: console.log("D1 Cached Status:", data.cached);
-	$: entries = data?.entries;
+
+	$: entries = data.entries;
 
 	let timerange = data.after ? new Date(data.after) : lastMonth;
 	$: category = null;

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -9,6 +9,7 @@
 
 	export let data;
 	$: console.log("D1 Cached Status:", data.cached);
+	$: console.log("URL origin: ", data.origin)
 
 	$: entries = data.entries;
 

--- a/src/routes/cache/delete/+server.ts
+++ b/src/routes/cache/delete/+server.ts
@@ -1,0 +1,17 @@
+import { D1CacheName, cacheInvalidate } from '$lib/storage';
+import { error, type RequestHandler } from '@sveltejs/kit';
+
+export const POST: RequestHandler = async ({ platform, request }) => {
+	if (platform === undefined) {
+		error(400, { message: 'Platform is undefined' });
+	}
+
+	if (platform.env.CACHEKEY !== request.headers.get(`${D1CacheName}-key`)) {
+		return error(401, { message: 'Action not authorized' });
+	}
+
+	const cache = await platform.caches.open(D1CacheName);
+	const response = await cacheInvalidate([], cache);
+
+	return new Response(JSON.stringify(response));
+};

--- a/src/routes/posts/+page.server.ts
+++ b/src/routes/posts/+page.server.ts
@@ -4,7 +4,7 @@ import type { PageServerLoad } from './$types';
 
 import { parseContent } from '$lib/parse';
 import type { Article } from '$lib/types';
-import { D1CacheName, cacheInvalidate, url } from '$lib/storage';
+import { D1CacheName, cacheInvalidate } from '$lib/storage';
 
 export const load: PageServerLoad = async ({ platform, url }) => {
 	const page = parseInt(url.searchParams.get('page') ?? '0');
@@ -58,7 +58,7 @@ export const load: PageServerLoad = async ({ platform, url }) => {
 };
 
 export const actions: Actions = {
-	update: async ({ request, platform }) => {
+	update: async ({ request, platform, url }) => {
 		if (platform === undefined) {
 			error(400, { message: 'Platform undefined' });
 		}
@@ -98,7 +98,7 @@ export const actions: Actions = {
 		}
 
 		const cache = await platform.caches.open(D1CacheName);
-		const baseUrl = platform.env.PRODUCTION === 'false' ? 'http://localhost:8788' : url;
+		const baseUrl = platform.env.PRODUCTION === 'true' ?  url.origin : 'http://localhost:8788';
 		platform.context.waitUntil(cacheInvalidate([baseUrl], cache));
 
 		redirect(304, String(data.get('path')));

--- a/src/routes/posts/+page.server.ts
+++ b/src/routes/posts/+page.server.ts
@@ -4,6 +4,7 @@ import type { PageServerLoad } from './$types';
 
 import { parseContent } from '$lib/parse';
 import type { Article } from '$lib/types';
+import { D1CacheName, cacheInvalidate, url } from '$lib/storage';
 
 export const load: PageServerLoad = async ({ platform, url }) => {
 	const page = parseInt(url.searchParams.get('page') ?? '0');
@@ -59,7 +60,7 @@ export const load: PageServerLoad = async ({ platform, url }) => {
 export const actions: Actions = {
 	update: async ({ request, platform }) => {
 		if (platform === undefined) {
-			error(400, { message: "Platform undefined"})
+			error(400, { message: 'Platform undefined' });
 		}
 
 		const data = await request.formData();
@@ -93,9 +94,13 @@ export const actions: Actions = {
 		}
 
 		if (response.meta.rows_written < 1) {
-			return fail(400, { message: "Failed to update article"})
+			return fail(400, { message: 'Failed to update article' });
 		}
-		
+
+		const cache = await platform.caches.open(D1CacheName);
+		const baseUrl = platform.env.PRODUCTION === 'false' ? 'http://localhost:8788' : url;
+		platform.context.waitUntil(cacheInvalidate([baseUrl], cache));
+
 		redirect(304, String(data.get('path')));
 	}
 };


### PR DESCRIPTION
Pulling this out of https://github.com/michigandaily/alt-text-tracker/pull/50 since there might be some additional concerns with exposing an endpoint that gives access to our cache.

This would allow the worker to access the cache from the pages side, allowing the worker to invalidate a cache from a different data center. Haven't tested if this would actually work yet.

However, there are two concerns:
1) I imagine (maybe) some CORS stuff will need to be set up to enable the worker to access the endpoint
2) The current implementation is vulnerable to a side channel attack, because the `===` operator in javascript terminates early if the string deviates earlier in number of letters from the secret key. In addition to this, if this gets implemented, it may be good to private this repo so outside people don't know the header used to share the auth/api key. 
- been thinking about a way to compare letter by letter manually to prevent a timing attack. Or maybe computing a hash so the user input and secret key have the same length. Or maybe it's not that big of a deal anyway lol. 

These considerations do take up more time though so I'm breaking this out into its own thing. 

